### PR TITLE
Reduce package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,8 @@
-/test
+/.github
+/.husky
+/tests
 /.jestrc-*
+/.*
+/utils
+/coverage*
+/_x-*


### PR DESCRIPTION
### What does this PR do?

The `.npmignore` wasn't ignoring a lot of unnecessary stuff.

**BEFORE:**

```bash
npm notice === Tarball Details ===
npm notice name:          @homer0/prettier-plugin-jsdoc
npm notice version:       7.0.0
npm notice filename:      @homer0/prettier-plugin-jsdoc-7.0.0.tgz
npm notice package size:  276.0 kB
npm notice unpacked size: 2.5 MB
npm notice shasum:        3242da8e32aa1499540f4ebbc8e2bc7cf314a2ca
npm notice integrity:     sha512-wl9dnXGE2gfIC[...]Fdhv9nEzozT7A==
npm notice total files:   244
```

**AFTER:**

```bash
npm notice === Tarball Details ===
npm notice name:          @homer0/prettier-plugin-jsdoc
npm notice version:       7.0.0
npm notice filename:      @homer0/prettier-plugin-jsdoc-7.0.0.tgz
npm notice package size:  43.5 kB
npm notice unpacked size: 181.2 kB
npm notice shasum:        593e516b783083296f26c7e9e5c6572dc8b859a9
npm notice integrity:     sha512-tFP2eSxiyx6EH[...]vewG0rFUZQNFA==
npm notice total files:   35
```

### How should it be tested manually?

```bash
npm pack
```