### PR TITLE
Remove top Node version limit from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": ">=18.17 <21"
+    "node": ">=18.17"
   },
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### What does this PR do?

Removing top range scope from `package.json` to allow package to be installed on Node 21 with strict engine checking.
