### PR TITLE
Fix links with custom labels

### DIFF
--- a/src/fns/splitText.js
+++ b/src/fns/splitText.js
@@ -156,7 +156,7 @@ const splitText = (text, length) => {
   let result = R.compose(
     R.addIndex(R.reduce)(get(reduceSentences)(length), ['']),
     R.reduce(get(reduceWordsList), []),
-    R.split(/(?<!\{@\w+) /),
+    R.split(/(?<!\{@\w+[^}]*) /),
     R.reduce(get(reduceText), ''),
   )(lines);
 

--- a/tests/e2e/fixtures/remarks-01.fixture.js
+++ b/tests/e2e/fixtures/remarks-01.fixture.js
@@ -27,6 +27,14 @@ module.exports = {
  */
 export function log(name = 'batman', logger) {}
 
+/**
+ * @type {Object} RemarkWithLink
+ * @remarks
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec malesuada fermentum {@link SomethingElse} nibh, sed aliquet ante porta a. Nullam blandit posuere fringilla. Nullam vel risus vitae lectus luctus auctor a venenatis ante. In hac habitasse platea dictumst.
+ * @privateRemarks
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec xx {@link SomethingElse | something} nibh, sed aliquet ante porta a. Nullam blandit posuere fringilla. Nullam vel risus vitae lectus luctus auctor a venenatis ante. In hac habitasse platea dictumst.
+ */
+
 //# output
 
 /**
@@ -47,3 +55,16 @@ export function log(name = 'batman', logger) {}
  * vitae lectus luctus auctor a venenatis ante. In hac habitasse platea dictumst.
  */
 export function log(name = 'batman', logger) {}
+
+/**
+ * @type {Object} RemarkWithLink
+ * @remarks
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec malesuada fermentum
+ * {@link SomethingElse} nibh, sed aliquet ante porta a. Nullam blandit posuere fringilla. Nullam
+ * vel risus vitae lectus luctus auctor a venenatis ante. In hac habitasse platea dictumst.
+ * @privateRemarks
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec xx
+ * {@link SomethingElse | something} nibh, sed aliquet ante porta a. Nullam blandit posuere
+ * fringilla. Nullam vel risus vitae lectus luctus auctor a venenatis ante. In hac habitasse platea
+ * dictumst.
+ */


### PR DESCRIPTION
### What does this PR do?

In #12, it was pointed out that the links with custom labels would still break when formatting descriptions. That was an issue in the regexp used to split the texts: it didn't consider complex tags.

### How should it be tested manually?

```bash
pnpm test
```